### PR TITLE
Add italics support

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -30,8 +30,8 @@ Plug 'mcasper/vim-infer-debugger'
 call plug#end()
 
 colorscheme cobalt2
-highlight Comment cterm=italic
-highlight htmlArg cterm=italic
+highlight Comment term=italic cterm=italic gui=italic
+highlight htmlArg term=italic cterm=italic gui=italic
 
 " Use filetype detection, as well as indent and plugins
 if has('autocmd')

--- a/vimrc
+++ b/vimrc
@@ -30,6 +30,8 @@ Plug 'mcasper/vim-infer-debugger'
 call plug#end()
 
 colorscheme cobalt2
+highlight Comment cterm=italic
+highlight htmlArg cterm=italic
 
 " Use filetype detection, as well as indent and plugins
 if has('autocmd')

--- a/xterm-256color-italic.terminfo
+++ b/xterm-256color-italic.terminfo
@@ -1,0 +1,13 @@
+# A xterm-256color based TERMINFO that adds the escape sequences for italic.
+#
+# Install:
+#
+#   tic xterm-256color-italic.terminfo
+#
+# Usage:
+#
+#   export TERM=xterm-256color-italic
+#
+xterm-256color-italic|xterm with 256 colors and italic,
+  sitm=\E[3m, ritm=\E[23m,
+  use=xterm-256color,


### PR DESCRIPTION
Much more complicated than you'd think.

See this excellent guide for a step-by-step on configuring iTerm2:
https://alexpearce.me/2014/05/italics-in-iterm2-vim-tmux/

The above link references this file, which I've copied over so the command is easier to manually run in the future:
https://gist.github.com/sos4nt/3187620

Used the following command to find the highlight group of the element under the cursor (via [/r/vim post](https://old.reddit.com/r/vim/comments/dgbvw4/how_can_i_have_italic_keywords_etc_in_neovim_like/)):
```viml
:exe 'hi '.synIDattr(synstack(line('.'), col('.'))[-1], 'name')
```

This page has more info about the different keys used for setting the style: https://www.sbf5.com/~cduan/technical/vi/vi-4.shtml

NOTE: this change strictly only targets HTML attributes, so variants (such as JSX) would need to be configured separately, or as part of a theme.