### PR TITLE
Show highlight groups

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -79,6 +79,15 @@ if maparg('<C-L>', 'n') ==# ''
   nnoremap <silent> <C-L> :nohlsearch<C-R>=has('diff')?'<Bar>diffupdate':''<CR><CR><C-L>
 endif
 
+" Add mapping to show highlight groups at current cursor position
+nnoremap <leader>sp :call <SID>SynStack()<CR>
+function! <SID>SynStack()
+  if !exists("*synstack")
+    return
+  endif
+  echo map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")')
+endfunc
+
 " Ensure that EditorConfig works well with fugitive
 let g:EditorConfig_exclude_patterns = ['fugitive://.*']
 


### PR DESCRIPTION
- will output all applied highlight groups at current cursor position
- map via leader key

Uses a common function that has been copied/pasted a lot, but I found it from this article (which also suggested a convenient key mapping):
https://jordanelver.co.uk/blog/2015/05/27/working-with-vim-colorschemes/

Also discussed here:
- https://stackoverflow.com/questions/9464844/how-to-get-group-name-of-highlighting-under-cursor-in-vim
- https://old.reddit.com/r/vim/comments/9zh4t4/til_its_easy_to_make_personal_overrides_for_a/

It looks like [tpope/vim-scriptease](https://github.com/tpope/vim-scriptease) includes this functionality, but I don't need the other features at this time, so the work in this PR should suffice.