### PR TITLE
Set default git pull operation

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -8,6 +8,8 @@
   insteadOf = https://github.com/
 [push]
   default = current
+[pull]
+  ff = only
 [alias]
   co = checkout
   ci = commit


### PR DESCRIPTION
A recent version of Git warns when pulling without a value specified in your configuration.

Setting to "fast forward" option to avoid making unintentional merge commits.

References:
- https://blog.sffc.xyz/post/185195398930/why-you-should-use-git-pull-ff-only
- https://stackoverflow.com/questions/62653114/how-to-deal-with-this-git-warning-pulling-without-specifying-how-to-reconcile
- https://old.reddit.com/r/git/comments/h7kv0y/git_2270_starts_yelling_during_pull/