### PR TITLE
Colorscheme modifications

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -34,6 +34,18 @@ colorscheme cobalt2
 highlight Comment term=italic cterm=italic gui=italic
 highlight htmlArg term=italic cterm=italic gui=italic
 
+" Syntax highlighting customizations not natively supported by colorscheme
+highlight jsFuncParens ctermfg=Yellow guifg=Yellow
+highlight htmlArg ctermfg=Yellow guifg=Yellow
+highlight htmlString ctermfg=LightGreen guifg=LightGreen
+
+highlight graphqlStructure ctermfg=Green guifg=Green
+highlight graphqlName ctermfg=Green guifg=Green
+highlight graphqlBraces ctermfg=Green guifg=Green
+
+highlight jsxComponentName ctermfg=LightGreen guifg=LightGreen
+highlight jsxEqual ctermfg=DarkYellow guifg=DarkYellow
+
 " Use filetype detection, as well as indent and plugins
 if has('autocmd')
   filetype plugin indent on

--- a/vimrc
+++ b/vimrc
@@ -44,7 +44,15 @@ highlight graphqlName ctermfg=Green guifg=Green
 highlight graphqlBraces ctermfg=Green guifg=Green
 
 highlight jsxComponentName ctermfg=LightGreen guifg=LightGreen
-highlight jsxEqual ctermfg=DarkYellow guifg=DarkYellow
+
+highlight link jsxOpenPunct htmlTag
+highlight link jsxClosePunct htmlTag
+highlight link jsxCloseString htmlTag
+highlight link jsxEqual htmlTag
+highlight link jsxTagName htmlTagName
+highlight link jsObjectKey htmlTagName
+highlight link jsxAttrib htmlArg
+highlight link jsString htmlString
 
 " Use filetype detection, as well as indent and plugins
 if has('autocmd')


### PR DESCRIPTION
Attempting to backfill some of the colorscheme settings to more closely match cobalt2.

Canonical source: https://github.com/wesbos/cobalt2-vscode/blob/master/theme/cobalt2.json

References:
[How to control/configure vim colors](https://alvinalexander.com/linux/vi-vim-editor-color-scheme-syntax/)

Confirmed that each item has a visible effect. Goal was to link jsx or JS highlight groups to an existing element where possible, and to manually set colors to mirror cobalt2 settings otherwise.