### PR TITLE
Configure some Netrw settings

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -95,6 +95,10 @@ nnoremap <expr> k v:count ? 'k' : 'gk'
 set splitbelow
 set splitright
 
+" Hide Netrw banner by default (toggle with `I`); add mapping to open one directory up
+let g:netrw_banner = 0
+nnoremap - :e %:h<cr>
+
 " Use <C-L> to clear the highlighting of :set hlsearch.
 if maparg('<C-L>', 'n') ==# ''
   nnoremap <silent> <C-L> :nohlsearch<C-R>=has('diff')?'<Bar>diffupdate':''<CR><CR><C-L>


### PR DESCRIPTION
- hide info section by default (toggle with `I`)
- map command to open file explorer one directory above current buffer

Was looking into [vim-vinegar](https://github.com/tpope/vim-vinegar), but all functionality is not needed.

Implemented just the minimum configuration per these resources:
- https://vi.stackexchange.com/questions/3711/how-do-i-avoid-exiting-vim-to-open-a-new-file/3719#3719
- https://old.reddit.com/r/vim/comments/ceoerh/back_to_netrw_from_vinegar/