### PR TITLE
Configure default global node packages

### DIFF
--- a/makesymlinks.sh
+++ b/makesymlinks.sh
@@ -12,6 +12,7 @@ olddir=~/dotfiles_old             # old dotfiles backup directory
 # list of files/folders to symlink in homedir
 files="
   rbenv/default-gems
+  nvm/default-packages
   ctags
   gitconfig
   gitignore_global

--- a/nvm/default-packages
+++ b/nvm/default-packages
@@ -1,0 +1,4 @@
+gatsby-cli
+lighthouse
+pa11y
+surge

--- a/nvm/default-packages
+++ b/nvm/default-packages
@@ -1,4 +1,8 @@
+gatsby
 gatsby-cli
 lighthouse
 pa11y
+react
+react-dom
 surge
+typescript


### PR DESCRIPTION
Implements the feature added in nvm-sh/nvm#1463:
https://github.com/nvm-sh/nvm#default-global-packages-from-file-while-installing

This will auto-install the specified packages upon each install of a new Node version via nvm. Included currently installed global packages, as well as most of the peer dependencies (which are no longer automatically installed).

Note that I did not include eslint, as they recommend not globally installing it, and any configs would need to be installed locally anyway. Also see: https://twitter.com/wesbos/status/1304502434417569793