### PR TITLE
Enable spell checking in vimrc

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -46,6 +46,8 @@ highlight graphqlBraces ctermfg=Green guifg=Green
 
 highlight jsxComponentName ctermfg=LightGreen guifg=LightGreen
 
+highlight SpellBad ctermfg=DarkRed guifg=DarkRed
+
 highlight link jsxOpenPunct htmlTag
 highlight link jsxClosePunct htmlTag
 highlight link jsxCloseString htmlTag

--- a/vimrc
+++ b/vimrc
@@ -127,6 +127,14 @@ nnoremap <C-p> :Files<CR>
 nnoremap <Leader>b :Buffers<CR>
 nnoremap <Leader>h :History<CR>
 
+" Spell-check Markdown files and Git Commit Messages
+autocmd FileType markdown setlocal spell
+autocmd FileType gitcommit setlocal spell
+
+" Enable dictionary auto-completion in Markdown files and Git Commit Messages
+autocmd FileType markdown setlocal complete+=kspell
+autocmd FileType gitcommit setlocal complete+=kspell
+
 " Set Emmet to apply jsx settings to javascript.jsx filetype
 let g:user_emmet_settings = {
       \  'javascript.jsx' : {


### PR DESCRIPTION
Have made far too many typos in commit messages and README files. Very much trained to rely on spell-checking (with it built into most operating systems).

Happy to see that Vim supports this natively without a plugin.

Relevant commands:
`z=` (normal mode): show corrections
`zg` (normal mode): add word to dictionary (mark as "good")
`]s` (normal mode): move to next misspelling
`[s` (normal mode): move to previous misspelling
`ctrl-n` (insert mode): show next suggestion
`ctrl-p` (insert mode): show previous suggestion

Helpful resources:
- [Enable Spell Checking in Vim for Markdown and Git Commit Messages](https://www.adamalbrecht.com/blog/2019/10/21/spell-check-in-vim-for-markdown-and-git-commit-messages/)
- [Vim Spell-Checking ](https://thoughtbot.com/blog/vim-spell-checking)
- [Spell Check in Vim](https://dancroak.com/spell-check-in-vim)