### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,22 @@
 # djpowers' dotfiles
 
-```bash
+Clone repo and navigate to directory:
+```shell
+git clone https://github.com/djpowers/dotfiles
 cd ~/dotfiles
+```
+
+Make the script to create symlinks executable, and run it:
+```shell
 chmod +x makesymlinks.sh
 ./makesymlinks.sh
 ```
 
+Install [Homebrew](https://brew.sh/) and run the `bundle` command to install packages:
+```shell
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+brew bundle
+```
+
 ### References
-* [USING GIT AND GITHUB TO MANAGE YOUR DOTFILES](http://blog.smalleycreative.com/tutorials/using-git-and-github-to-manage-your-dotfiles/)
+* [Using Git and GitHub to Manage Your Dotfiles](http://blog.smalleycreative.com/tutorials/using-git-and-github-to-manage-your-dotfiles/)

--- a/gitconfig
+++ b/gitconfig
@@ -3,9 +3,6 @@
   email = djpowers89@gmail.com
 [core]
   excludesfile = ~/.gitignore_global
-[url "git@github.com:"]
-  insteadOf = http://github.com/
-  insteadOf = https://github.com/
 [push]
   default = current
 [pull]

--- a/gitconfig
+++ b/gitconfig
@@ -3,6 +3,8 @@
   email = djpowers89@gmail.com
 [core]
   excludesfile = ~/.gitignore_global
+[url "ssh://git@github.com/"]
+  pushInsteadOf = https://github.com/
 [push]
   default = current
 [pull]


### PR DESCRIPTION
Clarify the steps to get everything in this repository up and running on a new environment.

This also tweaks the Git config setting to use SSH when pushing to GitHub (to avoid password prompts when using HTTPS), but allows pulling over HTTPS (so as to avoid breaking certain use cases).