### PR TITLE
Add bulldohzer NPM package for DNS benchmarking

### DIFF
--- a/nvm/default-packages
+++ b/nvm/default-packages
@@ -1,3 +1,4 @@
+bulldohzer
 gatsby
 gatsby-cli
 lighthouse


### PR DESCRIPTION
[bulldohzer guide](https://web.archive.org/web/20210515162023/https://help.commons.host/bulldohzer/cli/#examples)

Sources:
- https://www.reddit.com/r/dns/comments/ob87cn/dns_benchmark_mac/
- https://www.reddit.com/r/MacOS/comments/op19mg/is_there_a_dns_application_to_be_used_on_mac_os/

Also see  [DNS Performance Test](https://github.com/cleanbrowsing/dnsperftest) for a similar shell script option.