### PR TITLE
Add localtunnel to default node packages

### DIFF
--- a/nvm/default-packages
+++ b/nvm/default-packages
@@ -2,6 +2,7 @@ bulldohzer
 gatsby
 gatsby-cli
 lighthouse
+localtunnel
 npkill
 react
 react-dom


### PR DESCRIPTION
Adds [localtunnel](https://theboroer.github.io/localtunnel-www/) package to provide remote tunnel.

Provides another option besides [ngrok](https://ngrok.com/), which requires an account to serve HTML files (e.g., from Vue).

For use with a webpack dev server, use this command: `lt --port 8080 --local-host localhost` (see [this issue](https://github.com/localtunnel/localtunnel/issues/269#issuecomment-530575067))

Here are some other [ngrok alternatives](https://www.sitepoint.com/use-ngrok-test-local-site/#ngrokalternatives).

## Security Considerations
Most applications have some sort of security setting that will need to be changed to allow access from a specific domain

### Rails
In your environment file, add the URL to `config.hosts`:
```ruby
config.hosts << 'your-tunneling-service-url'
```
Reference:
- https://stackoverflow.com/questions/53878453/upgraded-rails-to-6-getting-blocked-host-error

### webpack
Ideally, something like this should be done (requires the `--local-host` flag as above):
```js
devServer: {
  compress: true,
  public: 'your-tunneling-service-url'
}
```
However, this also works as a less secure option:
```js
devServer: {
  disableHostCheck: true,
},
```
Reference:
- https://stackoverflow.com/questions/45425721/invalid-host-header-when-ngrok-tries-to-connect-to-react-dev-server
- https://stackoverflow.com/questions/43619644/i-am-getting-an-invalid-host-header-message-when-connecting-to-webpack-dev-ser
- https://stackoverflow.com/questions/51084089/vuejs-app-showing-invalid-host-header-error-loop