### PR TITLE
Add alpha-nvim to use custom startup screen

### DIFF
--- a/config/nvim/lua/user/plugins.lua
+++ b/config/nvim/lua/user/plugins.lua
@@ -47,6 +47,15 @@ return require('packer').startup(function(use)
   use "tpope/vim-unimpaired" -- Pairs of handy bracket mappings
   use "tpope/vim-rails" -- Ruby on Rails power tools
 
+  -- startup
+  use {
+    'goolord/alpha-nvim',
+    requires = { 'nvim-tree/nvim-web-devicons' },
+    config = function ()
+      require'alpha'.setup(require'alpha.themes.theta'.config)
+    end
+  }
+
   -- Colorschemes
   use 'shaunsingh/nord.nvim' -- An arctic, north-bluish clean and elegant Vim theme
 


### PR DESCRIPTION
# Add alph-nvim to use custom startup screen
- use "theta" theme, a hybrid of sorts of Dashboard and Startify

## Rationale
Had been meaning to explore start screen options, but noticed that a NeoVim bug was causing lualine to clear the intro screen automatically: nvim-lualine/lualine.nvim#773
One suggested workaround was to try a dashboard plugin, hence this addition.

## Plugin options
### [alpha-nvim](https://github.com/goolord/alpha-nvim) ✅
- [What's the best start up screen written in Lua? : r/neovim](https://www.reddit.com/r/neovim/comments/tryz82/whats_the_best_start_up_screen_written_in_lua/)
- used in both [LunarVim core plugins list](https://www.lunarvim.org/docs/plugins/core-plugins-list) and [NvChad core lugins](https://nvchad.com/Features#alpha-nvim)
- https://github.com/goolord/alpha-nvim/discussions/16
- [alpha-nvim: lua powered startup screen : r/neovim](https://www.reddit.com/r/neovim/comments/pj99r4/alphanvim_lua_powered_startup_screen/)
#### Theme options
##### Startify
- left-aligned by default
- MRU for other projects not useful for me
##### Dashboard
- nice layout
- some odd default keybinding choices, didn't want to customize
##### Theta
- suggested "mixed way" from Reddit discussion
- best of both words, MRU in directory, sensible basic commands
### [dashboard-nvim](https://github.com/glepnir/dashboard-nvim)
- active development, lots of GitHub stars
- inspiration for alpha-nvim
- default themes not to my taste
### [startup.nvim](https://github.com/startup-nvim/startup.nvim)
- [Startup.nvim: The fully customizable greeter for neovim : r/neovim](https://www.reddit.com/r/neovim/comments/rig8z6/startupnvim_the_fully_customizable_greeter_for/)
- currently seeking maintainer
### [vim-startify](https://github.com/mhinz/vim-startify)
- Vim Script plugin, looking for Lua option