### PR TITLE
Setup mini.nvim modules

### DIFF
--- a/config/nvim/lua/user/keymaps.lua
+++ b/config/nvim/lua/user/keymaps.lua
@@ -31,10 +31,6 @@ end
 vim.api.nvim_set_keymap('n', '<Leader>sv', '<Cmd>lua ReloadConfig()<CR>', opts)
 vim.cmd('command! ReloadConfig lua ReloadConfig()')
 
--- Move up and down by physical lines if using a count, otherwise by visible lines
-vim.api.nvim_set_keymap("n", "j", "v:count ? 'j' : 'gj'", { noremap = true, expr = true })
-vim.api.nvim_set_keymap("n", "k", "v:count ? 'k' : 'gk'", { noremap = true, expr = true })
-
 -- Visual --
 -- Stay in indent mode
 keymap("v", "<", "<gv", opts)

--- a/config/nvim/lua/user/mini-nvim.lua
+++ b/config/nvim/lua/user/mini-nvim.lua
@@ -1,0 +1,18 @@
+require('mini.basics').setup({
+  options = {
+    basic = false,
+    extra_ui = false,
+    win_borders = 'default',
+  },
+  mappings = {
+    basic = true,
+    option_toggle_prefix = [[\]],
+    windows = false,
+    move_with_alt = false,
+  },
+  autocommands = {
+    basic = true,
+    relnum_in_visual_mode = false,
+  }
+})
+require('mini.bracketed').setup()

--- a/config/nvim/lua/user/plugin-setups.lua
+++ b/config/nvim/lua/user/plugin-setups.lua
@@ -2,4 +2,3 @@
 require('fidget').setup()
 require('leap').set_default_keymaps()
 require"gitlinker".setup()
-require('mini.bracketed').setup()

--- a/config/nvim/lua/user/plugin-setups.lua
+++ b/config/nvim/lua/user/plugin-setups.lua
@@ -2,3 +2,4 @@
 require('fidget').setup()
 require('leap').set_default_keymaps()
 require"gitlinker".setup()
+require('mini.bracketed').setup()

--- a/config/nvim/lua/user/plugins.lua
+++ b/config/nvim/lua/user/plugins.lua
@@ -42,9 +42,10 @@ return require('packer').startup(function(use)
   use "NvChad/nvim-colorizer.lua" -- Maintained fork of the fastest Neovim colorizer
   use "gpanders/editorconfig.nvim" -- Maintian consistent coding styles
   use "ggandor/leap.nvim" -- Lightning-fast movements in the visible editor area
+  use "echasnovski/mini.bracketed" -- Go forward/backward with square brackets
 
   -- tpope plugins (Vimscript)
-  use "tpope/vim-unimpaired" -- Pairs of handy bracket mappings
+  -- use "tpope/vim-unimpaired" -- Pairs of handy bracket mappings
   use "tpope/vim-rails" -- Ruby on Rails power tools
 
   -- startup

--- a/config/nvim/lua/user/plugins.lua
+++ b/config/nvim/lua/user/plugins.lua
@@ -42,6 +42,9 @@ return require('packer').startup(function(use)
   use "NvChad/nvim-colorizer.lua" -- Maintained fork of the fastest Neovim colorizer
   use "gpanders/editorconfig.nvim" -- Maintian consistent coding styles
   use "ggandor/leap.nvim" -- Lightning-fast movements in the visible editor area
+
+  -- mini.nvim
+  use "echasnovski/mini.basics" -- Common configuration presets
   use "echasnovski/mini.bracketed" -- Go forward/backward with square brackets
 
   -- tpope plugins (Vimscript)

--- a/makesymlinks.sh
+++ b/makesymlinks.sh
@@ -30,6 +30,7 @@ files="
   config/nvim/lua/user/plugin-setups.lua
   config/nvim/lua/user/colorizer.lua
   config/nvim/lua/user/neotest.lua
+  config/nvim/lua/user/mini-nvim.lua
   config/starship.toml
   rbenv/default-gems
   nvm/default-packages


### PR DESCRIPTION
# Add mini.nvim modules

Reference survey for mini.basics options: https://www.reddit.com/r/neovim/comments/zg44mm/results_of_neovim_builtin_options_survey_more_in/

## mini.bracketed
- Go forward/backward with square brackets
- (Mostly) replaces [vim-unimpaired](https://github.com/tpope/vim-unimpaired)
- Letting `comment` target be overwritten due to conflict with gitsigns, as mentioned in https://github.com/echasnovski/mini.nvim/issues/235
- https://this-week-in-neovim.org/2023/Feb/27#new-mini.bracketed
- https://www.reddit.com/r/neovim/comments/118511i/minibracketed_go_forwardbackward_with_square/
- https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-bracketed.md

## mini.basics
- "Toggle" options from vim-unimpaired available here
- "Add line above/below" from vim-unimpaired available here
- "Paste above/below" may be added in future
- https://www.reddit.com/r/neovim/comments/10o5sjm/minibasics_common_configuration_presets_for/
- https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-basics.md