### PR TITLE
Optimize suspend usage

### DIFF
--- a/config/fish/config.fish
+++ b/config/fish/config.fish
@@ -9,6 +9,9 @@ if status is-interactive
   set -gx EDITOR nvim
   set -gx BAT_THEME Nord
 
+  # map Ctrl-z to bring last suspended job to foreground
+  bind \cz "fg 2>/dev/null; commandline -f repaint"
+
   # customize fzf.fish key bindings
   fzf_configure_bindings --directory=\ct --history=\ch
 

--- a/config/nvim/lua/user/mini-nvim.lua
+++ b/config/nvim/lua/user/mini-nvim.lua
@@ -15,4 +15,7 @@ require('mini.basics').setup({
     relnum_in_visual_mode = false,
   }
 })
+-- Delete "Correct latest misspelled word" keymap in normal mode, as it overwrites the "suspend" feature
+vim.keymap.del('n', '<C-z>')
+
 require('mini.bracketed').setup()


### PR DESCRIPTION
# Goal
- to decide on a simple and reliable way of accessing a terminal while using Neovim
## Decision
- for now, going with the Unix "suspend" feature (Ctrl-z), and adding a keybinding to use this same combination to bring the latest program back to the foreground (`fg`)
- this seemed to be the most straightforward option, not requiring other plugins, plus is a portable convention used in many other terminal-based programs
  - I may consider the built-in `:terminal` command or a toggle/floating option in the future, but I didn't want to be dealing with inception-sytle nvim-inside-shell-inside-nvim-inside-shell chaos, or needing to work around it
## Notes
- needed to fix an override in mini.basics to get this to work (otherwise only Ctrl+shift+z worked)

# Options considered:
## toggleterm.nvim
- https://github.com/akinsho/toggleterm.nvim
- [Neovim - Toggleterm | Open terminal programs in Neovim](https://www.youtube.com/watch?v=5OD-7h7gzxU)
## vim-floaterm
- https://github.com/voldikss/vim-floaterm
## flatten
- https://www.reddit.com/r/neovim/comments/11o53jg/flattennvim_open_files_from_a_neovim_terminal_in/
## suspend (Ctrl-z)
- https://neovim.io/doc/user/usr_21.html#21.1
- https://joshtronic.com/2019/07/15/how-to-exit-vim/
- https://www.rockyourcode.com/suspend-vim-to-the-background-or-what-is-linux-job-control/
- https://willcodefor.beer/posts/susvim
### Reddit
- https://www.reddit.com/r/neovim/comments/hbq9rm/terminal_vs_ctrlz/
- https://www.reddit.com/r/vim/comments/d1nwhl/ctrlz_vs_shell/