### PR TITLE
Add prettier and configure for Vue formatting

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -23,6 +23,7 @@ brew "neofetch"
 brew "node"
 brew "ocrmypdf"
 brew "postgresql", restart_service: true
+brew "prettier"
 brew "rbenv"
 brew "rbenv-default-gems"
 brew "redis", restart_service: true

--- a/config/helix/languages.toml
+++ b/config/helix/languages.toml
@@ -17,6 +17,7 @@ injection-regex = "vue"
 language-server = { command = "vue-language-server", args = ["--stdio"] }
 roots = ["package.json"]
 scope = "text.html.vue"
+formatter = { command = "npx", args = ["prettier", "--parser", "vue"]}
 
 [language.config.typescript]
 tsdk = "/opt/homebrew/opt/typescript/libexec/lib/node_modules/typescript/lib"


### PR DESCRIPTION
- set up to run locally installed version: https://prettier.io/docs/en/cli.html
- reference: https://github.com/helix-editor/helix/wiki/External-binary-formatter-configuration#prettier

Prettier formatting was not working properly for other filetypes, so I'll revisit later.