### PR TITLE
Configure search params for fzf.fish search dir

### DIFF
--- a/fish/.config/fish/config.fish
+++ b/fish/.config/fish/config.fish
@@ -17,6 +17,9 @@ if status is-interactive
     # customize fzf.fish key bindings
     fzf_configure_bindings --directory=\ct --history=\ch
 
+    # limit fzf.fish to files only; include hidden files, but not .git
+    set fzf_fd_opts --type f --hidden --exclude=.git
+
     # set default source for fzf; respect gitignore
     set -gx FZF_DEFAULT_COMMAND 'fd --type f --strip-cwd-prefix --hidden --follow --exclude .git'
 


### PR DESCRIPTION
- default options do not include hidden files, which is now necessary in the dotfiles repository with the new symlink process
- reference: https://github.com/PatrickF1/fzf.fish#change-what-files-are-listed-in-search-directory
- used default example from docs, but needed to scope to files as to not display directories
- may look into consolidating with default fzf command

Fixes an issue related to changes in #39