### PR TITLE
Add Prettier formatting for remaining formats

### DIFF
--- a/helix/.config/helix/languages.toml
+++ b/helix/.config/helix/languages.toml
@@ -34,6 +34,7 @@ formatter = { command = 'npx', args = ["prettier", "--parser", "html"] }
 
 [[language]]
 name = "json"
+config = { "json" = { "validate" = { "enable" = true } } }
 formatter = { command = 'npx', args = ["prettier", "--parser", "json"] }
 
 [[language]]

--- a/helix/.config/helix/languages.toml
+++ b/helix/.config/helix/languages.toml
@@ -39,6 +39,7 @@ formatter = { command = 'npx', args = ["prettier", "--parser", "json"] }
 
 [[language]]
 name = "css"
+config = { "css" = { validate = { enable = true } } }
 formatter = { command = 'npx', args = ["prettier", "--parser", "css"] }
 
 [[language]]

--- a/helix/.config/helix/languages.toml
+++ b/helix/.config/helix/languages.toml
@@ -29,5 +29,9 @@ name = "yaml"
 keyOrdering = false
 
 [[language]]
+name = "html"
+formatter = { command = 'npx', args = ["prettier", "--parser", "html"] }
+
+[[language]]
 name = "json"
 formatter = { command = 'npx', args = ["prettier", "--parser", "json"] }

--- a/helix/.config/helix/languages.toml
+++ b/helix/.config/helix/languages.toml
@@ -27,3 +27,7 @@ name = "yaml"
 
 [language.config.yaml]
 keyOrdering = false
+
+[[language]]
+name = "json"
+formatter = { command = 'npx', args = ["prettier", "--parser", "json"] }

--- a/helix/.config/helix/languages.toml
+++ b/helix/.config/helix/languages.toml
@@ -35,3 +35,7 @@ formatter = { command = 'npx', args = ["prettier", "--parser", "html"] }
 [[language]]
 name = "json"
 formatter = { command = 'npx', args = ["prettier", "--parser", "json"] }
+
+[[language]]
+name = "css"
+formatter = { command = 'npx', args = ["prettier", "--parser", "css"] }

--- a/helix/.config/helix/languages.toml
+++ b/helix/.config/helix/languages.toml
@@ -39,3 +39,18 @@ formatter = { command = 'npx', args = ["prettier", "--parser", "json"] }
 [[language]]
 name = "css"
 formatter = { command = 'npx', args = ["prettier", "--parser", "css"] }
+
+[[language]]
+name = "javascript"
+formatter = { command = 'npx', args = ["prettier", "--parser", "typescript"] }
+auto-format = true
+
+[[language]]
+name = "typescript"
+formatter = { command = 'npx', args = ["prettier", "--parser", "typescript"] }
+auto-format = true
+
+[[language]]
+name = "tsx"
+formatter = { command = 'npx', args = ["prettier", "--parser", "typescript"] }
+auto-format = true


### PR DESCRIPTION
This builds on top of #38, and closes helix-editor/helix#7155.

Based on the [External binary formatter configuration for Prettier](https://github.com/helix-editor/helix/wiki/External-binary-formatter-configuration#prettier), this enables Prettier formatting for HTML, JSON, CSS, and JS/TS filetypes.

The default language server formatters work (see [JSON setup instructions](https://github.com/helix-editor/helix/wiki/How-to-install-the-default-language-servers#json)), but some removed ending newlines (which in some cases I could not disable). Plus it seems worth overriding this anyway since many projects are already using Prettier, and the LSP formatters may stray from Prettier rules.

I set things up to use the local version of Prettier, per the [install docs](https://prettier.io/docs/en/install.html). My dotfiles also install Prettier via Homebrew, so it *should* be available, even if not installed locally for a given project.

To verify Prettier formatting was being applied as opposed to LSP formatting, I copied my test files into the [Prettier playground](https://prettier.io/playground/) and selected the corresponding parser to make sure the `:format` command matched this output.

It also enables validation for the JSON and CSS servers, which currently needs to be manually set. Doing so enables diagnostics (HTML does not support them, and TypeScript seems to get them by default).