### PR TITLE
Update Helix language config

### DIFF
--- a/helix/.config/helix/languages.toml
+++ b/helix/.config/helix/languages.toml
@@ -40,12 +40,10 @@ formatter = { command = 'npx', args = ["prettier", "--parser", "html"] }
 
 [[language]]
 name = "json"
-config = { "json" = { "validate" = { "enable" = true } } }
 formatter = { command = 'npx', args = ["prettier", "--parser", "json"] }
 
 [[language]]
 name = "css"
-config = { "css" = { validate = { enable = true } } }
 formatter = { command = 'npx', args = ["prettier", "--parser", "css"] }
 
 [[language]]

--- a/helix/.config/helix/languages.toml
+++ b/helix/.config/helix/languages.toml
@@ -29,12 +29,6 @@ formatter = { command = "npx", args = ["prettier", "--parser", "vue"]}
 tsdk = "/opt/homebrew/opt/typescript/libexec/lib/node_modules/typescript/lib"
 
 [[language]]
-name = "yaml"
-
-[language.config.yaml]
-keyOrdering = false
-
-[[language]]
 name = "html"
 formatter = { command = 'npx', args = ["prettier", "--parser", "html"] }
 

--- a/helix/.config/helix/languages.toml
+++ b/helix/.config/helix/languages.toml
@@ -15,18 +15,22 @@ language-servers = [
   "solargraph",
 ]
 
+[language-server.vue-language-server]
+command = "vue-language-server"
+args = ["--stdio"]
+
+[language-server.vue-language-server.config]
+typescript = { tsdk = "/opt/homebrew/opt/typescript/libexec/lib/node_modules/typescript/lib" }
+
 [[language]]
 name = "vue"
-auto-format = true
+scope = "source.vue"
 file-types = ["vue"]
 injection-regex = "vue"
-language-server = { command = "vue-language-server", args = ["--stdio"] }
 roots = ["package.json"]
-scope = "text.html.vue"
-formatter = { command = "npx", args = ["prettier", "--parser", "vue"]}
-
-[language.config.typescript]
-tsdk = "/opt/homebrew/opt/typescript/libexec/lib/node_modules/typescript/lib"
+language-servers = ["vue-language-server"]
+formatter = { command = "npx", args = ["prettier", "--parser", "vue"] }
+auto-format = true
 
 [[language]]
 name = "html"

--- a/helix/.config/helix/languages.toml
+++ b/helix/.config/helix/languages.toml
@@ -3,11 +3,17 @@ name = "fish"
 formatter = { command = "fish_indent" }
 auto-format = true
 
+[language-server.rubocop]
+command = "bundle"
+args = ["exec", "rubocop", "--lsp"]
+
 [[language]]
 name = "ruby"
-config = { solargraph = { diagnostics = true, formatting = false } }
-formatter = { command = "bundle", args = ["exec", "rubocop", "--stdin", "foo.rb", "-a", "--stderr", "--fail-level", "fatal"] }
 auto-format = true
+language-servers = [
+  { name = "rubocop" },
+  "solargraph",
+]
 
 [[language]]
 name = "vue"

--- a/node/.nvm/default-packages
+++ b/node/.nvm/default-packages
@@ -1,2 +1,2 @@
-@volar/vue-language-server
+@vue/language-server@1.7.8
 svelte-language-server

--- a/ruby/.rbenv/default-gems
+++ b/ruby/.rbenv/default-gems
@@ -1,3 +1,2 @@
 rails
-rubocop
 solargraph

--- a/ruby/.rbenv/default-gems
+++ b/ruby/.rbenv/default-gems
@@ -1,2 +1,3 @@
 rails
 rubocop
+solargraph


### PR DESCRIPTION
Update the language config due to [changes in the Helix 23.10 releas](https://helix-editor.com/news/release-23-10-highlights/).

See new LSP arguments here: https://docs.helix-editor.com/languages.html#language-server-configuration

This also adds `solargraph` to the default gems so it will be available in all Ruby projects. For now, I've removed `rubocop` and will plan to `bundle install` it when necessary.

## References

### Solargraph
- using default config

### RuboCop LSP
- https://docs.rubocop.org/rubocop/usage/lsp.html#helix

### Vue language server
- https://github.com/helix-editor/helix/wiki/How-to-install-the-default-language-servers#vue