### PR TITLE
Add create-vite to default global packages

### DIFF
--- a/node/.nvm/default-packages
+++ b/node/.nvm/default-packages
@@ -1,2 +1,3 @@
 @vue/language-server@1.7.8
+create-vite
 svelte-language-server


### PR DESCRIPTION
Include the [`create-vite` package](https://www.npmjs.com/package/create-vite), which allows bootstrapping a new Vite project with `npm create vite@latest`.

Part of an exploration into creating a new Vite-based application while offline.

Once a project is created for a given framework (e.g., React) and dependencies are installed, running `npm cache ls` will show the request cache for NPM.

To ensure packages are cached from the start (without creating a new project) the dependencies for your chosen framework can be installed globally. (I chose not to do this for now since I'd rather not install a handful of extra packages with every new Node.js version installation.)

Also of note is the `npm config get cache` command to view the path to the NPM cache (e.g., `~/.npm/_npx`), where a hashed directory name will contain the install packages within the `node_modules` folder.

The `--offline` flag can be passed to the `npm create` command or `npm install` commands, provided the required dependencies are cached as described above.

See additional context in [this Stack Overflow answer](https://stackoverflow.com/a/77385236/2566838).