### PR TITLE
Add iTerm page scroll key bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ brew bundle
 stow --verbose */
 ```
 
+### 🖥️  Import iTerm2 key bindings
+iTerm2 > Settings > Keys > Key Bindings > Presets... > Import... (Keep existing mappings)
+```shell
+~/dotfiles/iterm/key_bindings
+```
+- allows scrolling one page up and down with <kbd>⌃</kbd><kbd>⌥</kbd><kbd>⌘</kbd><kbd>j</kbd> and <kbd>⌃</kbd><kbd>⌥</kbd><kbd>⌘</kbd><kbd>k</kbd>, respectively
+
 ### 🔰 Install [Node.js](https://nodejs.org/en/)
 
 ```shell

--- a/iterm/key_bindings/jk_page_scroll.itermkeymap
+++ b/iterm/key_bindings/jk_page_scroll.itermkeymap
@@ -1,0 +1,1 @@
+{"Key Mappings":{"0x6b-0x1c0000-0x28":{"Version":2,"Apply Mode":0,"Action":9,"Text":"","Escaping":2},"0x6a-0x1c0000-0x26":{"Version":2,"Apply Mode":0,"Action":8,"Text":"","Escaping":2}},"Touch Bar Items":{}}


### PR DESCRIPTION
The default [iTerm2 key bindings](https://iterm2.com/documentation-preferences-keys.html) for scrolling use <kbd>⌘</kbd> arrow keys for scrolling by one line, and <kbd>⇧</kbd>/<kbd>⌘</kbd> <kbd>Page Up</kbd> and <kbd>Page Down</kbd> for scrolling by page, neither of which is super convenient (I generally try to avoid moving to arrow keys, and keyboards with smaller layouts need to rely on the <kbd>fn</kbd> key).

As noted in the documentation linked above, iTerm allows you to Import/Export Presets, which is what I've added here (which requires a manual step).

I was going to use cmd-shift-J and cmd-shift-K, but the former was [already in use](https://iterm2.com/documentation-one-page.html), and the latter appeared to be used for "Clear Scrollback Buffer," so I'd prefer not to overwrite them.

Using <kbd>⌃</kbd><kbd>⌥</kbd><kbd>⌘</kbd><kbd>j</kbd>/<kbd>k</kbd> will scroll up or down by one page. I don't often use single-line scrolling, so this should suffice.