### PR TITLE
Update git config to use `includeIf` for different profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ Edit this configuration in `~/.gitconfig-work`:
 Ensure relevant repositories are stored under `~/work/`.
 
 ### 🛠️ Install tools
-- 🔰[Node.js](https://nodejs.org/en/): `mise use -g node`
-- 💎[Ruby](https://www.ruby-lang.org/en/): `mise use -g ruby`
-- 🔮[Elixir](https://elixir-lang.org/): `mise use -g erlang elixir`
+Running `mise install` will install the following:
+- 🔰[Node.js](https://nodejs.org/en/)
+- 💎[Ruby](https://www.ruby-lang.org/en/)
+- 🔮[Elixir](https://elixir-lang.org/)
 
 ### 🐟 Set [fish](https://fishshell.com/) as default shell
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ brew bundle
 ```
 stow --verbose */
 ```
+### 💼 Work (optional)
+
+Configure git config to use different name/email.
+
+Edit this configuration in `~/.gitconfig-work`:
+```shell
+[user]
+  name = WORK_NAME
+  email = WORK_EMAIL
+```
+Ensure relevant repositories are stored under `~/work/`.
 
 ### 🛠️ Install tools
 - 🔰[Node.js](https://nodejs.org/en/): `mise use -g node`

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Running `mise install` will install the following:
 - 🔰[Node.js](https://nodejs.org/en/)
 - 💎[Ruby](https://www.ruby-lang.org/en/)
 - 🔮[Elixir](https://elixir-lang.org/)
+Run `mise install ruby` to install just that tool.
 
 ### 🐟 Set [fish](https://fishshell.com/) as default shell
 

--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -1,6 +1,8 @@
 [user]
   name = Dave Powers
   email = djpowers89@gmail.com
+[includeIf "gitdir:~/work/"]
+  path = ~/.gitconfig-work
 [core]
   excludesfile = ~/.gitignore_global
 [init]

--- a/git/.gitignore_global
+++ b/git/.gitignore_global
@@ -1,2 +1,1 @@
 .DS_store
-node_modules/

--- a/git/.gitignore_global
+++ b/git/.gitignore_global
@@ -1,3 +1,2 @@
 .DS_store
-tags
 node_modules/


### PR DESCRIPTION
Updates git config to make it easier to have separate/conditional git profiles based on directory.

For example, repositories within `~/work/` can use a work-specific email address for any commits, while leaving a default email in use outside of this folder. Added setup instructions to README.

References:
- https://nicknisi.com/posts/git-includeif/
- https://www.vincentschmalbach.com/git-includeif-the-config-superpower-you-didnt-know-about/
- https://maiobarbero.dev/articles/using-different-git-identities-per-folder-with-includeifgitdir/
- https://kewah.com/managing-multiple-gitconfig-with-includeif/
- https://wempe.dev/blog/git-config-includes

This also simplifies the install steps for programming languages, as those are already specified in the mise TOML file.

Also cleaned up the global gitignore to remove outdated/unnecessary items.