### PR TITLE
Configure git commit msg hook for Conventional Commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Brewfile.lock.json
+git/.githooks/commit-msg

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Edit this configuration in `~/.gitconfig-work`:
 ```
 Ensure relevant repositories are stored under `~/work/`.
 
+Enable git hooks to enforce conventional commits:
+```shell
+cp ~/.githooks/commit-msg.sample ~/.githooks/commit-msg
+chmod +x .githooks/commit-msg # make executable
+```
+
 ### 🛠️ Install tools
 Running `mise install` will install the following:
 - 🔰[Node.js](https://nodejs.org/en/)

--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -5,6 +5,7 @@
   path = ~/.gitconfig-work
 [core]
   excludesfile = ~/.gitignore_global
+  hooksPath = ~/.githooks/
 [init]
   defaultBranch = main
 [url "ssh://git@github.com/"]

--- a/git/.githooks/commit-msg.sample
+++ b/git/.githooks/commit-msg.sample
@@ -1,8 +1,5 @@
 #!/bin/sh
-commit_msg=$(cat "$1")
-pattern="^(feat|fix|docs|style|refactor|test|chore)\: .+$"
-
-if ! echo "$commit_msg" | grep -qE "$pattern"; then
-  echo "Invalid commit message. Use Conventional Commits (e.g., 'feat: add login button')"
-  exit 1
+if type cog &> /dev/null; then
+  set -e
+  cog verify --file $1
 fi

--- a/git/.githooks/commit-msg.sample
+++ b/git/.githooks/commit-msg.sample
@@ -1,0 +1,8 @@
+#!/bin/sh
+commit_msg=$(cat "$1")
+pattern="^(feat|fix|docs|style|refactor|test|chore)\: .+$"
+
+if ! echo "$commit_msg" | grep -qE "$pattern"; then
+  echo "Invalid commit message. Use Conventional Commits (e.g., 'feat: add login button')"
+  exit 1
+fi


### PR DESCRIPTION
The [git hooks from Cocogitto](https://docs.cocogitto.io/guide/git_hooks.html) are currently project-specific. This sets up a more generic way to have a global commit message hook, using the `cog` command.

It will only run if the script has been copied to a new file with the `.sample` suffix removed, if the file has been made executable, and if the the cog binary is available.

This gave a good shell-only option to enforce a pattern and reminds that it must be made executable: https://thedevopsdojo.substack.com/p/5-git-hooks-to-instantly-improve (considered running this when `cog` is not found, but decided to keep things flexible).

This [Atlassian Git hooks tutorial](https://www.atlassian.com/git/tutorials/git-hooks) provides a good example of the different available hooks, and suggested the `.sample` suffix convention.

[Applying a git post-commit hook to all current and future repositories](https://stackoverflow.com/questions/2293498/applying-a-git-post-commit-hook-to-all-current-and-future-repositories) covered the same initial question, and answers led to the `core.hooksPath` config option:
- https://git-scm.com/docs/githooks
- https://git-scm.com/docs/git-config

Of note, git did not like trying to symlink over a `.git/` directory, so I used `.githooks/` instead, inspired by https://stackoverflow.com/questions/39332407/git-hooks-applying-git-config-core-hookspath.